### PR TITLE
feat: WebMvcConfig 생성

### DIFF
--- a/src/main/java/com/skyhorsemanpower/chatService/common/WebMvcConfig.java
+++ b/src/main/java/com/skyhorsemanpower/chatService/common/WebMvcConfig.java
@@ -1,0 +1,29 @@
+package com.skyhorsemanpower.chatService.common;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        configurer.setTaskExecutor(mvcTaskExecutor());
+    }
+
+    @Bean(name = "mvcTaskExecutor")
+    public AsyncTaskExecutor mvcTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);  // 기본 스레드 수
+        executor.setMaxPoolSize(20);   // 최대 스레드 수
+        executor.setQueueCapacity(30); // 큐 용량
+        executor.setThreadNamePrefix("mvc-task-");
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
ThreadPoolTaskExecutor의 설정 값에 따라 메모리 사용량과 CPU 부하가 달라짐.

아까 제가 질문했을 때 동시에 1000명 정도가 대화한다고 하셔서 gpt한테 물어보니 계산을 저렇게 해줬습니다.
1000명 정도의 사용자를 처리할 수 있도록 설정할 때 예상되는 메모리 사용량 추정

메모리 사용량 계산

스레드 스택 크기: JVM의 기본 스택 크기는 보통 1MB(조정 가능)

기본 설정으로 인한 메모리 사용량:
- Core Pool Size: 500
- Max Pool Size: 1000
- Queue Capacity: 1500

스레드 메모리 사용량:
기본 스레드 수(Core Pool Size)의 메모리 사용량: 500 threads * 1MB = 500MB
최대 스레드 수(Max Pool Size)로 확장될 경우: 1000 threads * 1MB = 1000MB

큐 용량으로 인한 메모리 사용량:
큐 용량은 작업 객체의 크기에 따라 달라짐
각 작업 객체가 1KB를 사용한다고 가정하면, 1500개의 작업은 1.5MB의 메모리를 사용

총 메모리 사용량
최악의 경우를 가정해, 모든 스레드가 사용 중이며 큐가 꽉 차 있는 상황

- 최대 스레드 수: 1000MB
- 큐의 작업 객체: 1.5MB
- 기타 메모리 오버헤드(스레드 로컬 변수, JVM 메타데이터 등): 100MB~200MB

따라서 총 메모리 사용량은:

총 메모리 사용량 = 스레드 메모리 + 큐 메모리 + 기타 오버헤드
총 메모리 사용량 = 1000MB + 1.5MB + 100MB~200MB ≈ 1101.5MB~1201.5MB

메모리 사용량이 너무 큰 것 같아서 
- Core Pool Size: 10
- Max Pool Size: 20
- Queue Capacity: 30
만 설정하고 실제로 필요할 때 늘리는게 맞는것 같습니다.